### PR TITLE
rtd: use python 3.10 for docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,6 @@
+version: 2
+
+python:
+  version: "3.8"
+  install:
+    - path: .


### PR DESCRIPTION
The default is 3.7 which is not compatible.