### PR TITLE
Gracefully fall back if a storage has no base_url

### DIFF
--- a/.builds/python3.11.yml
+++ b/.builds/python3.11.yml
@@ -1,16 +1,15 @@
-image: alpine/3.19
+image: debian/bookworm
 packages:
-  - alpine-sdk
-  - cairo-dev
-  - gcc
-  - gdk-pixbuf-dev
-  - jpeg-dev
+  - build-essential
+  - fonts-dejavu
+  - libcairo2-dev
   - libffi-dev
-  - font-dejavu
-  - musl-dev
-  - pango-dev
-  - py3-tox
-  - zlib-dev
+  - libgdk-pixbuf2.0-dev
+  - libjpeg-dev
+  - libpango1.0-dev
+  - python3-dev
+  - tox
+  - zlib1g-dev
 sources:
   - https://github.com/whyNotHugo/django-renderpdf
 environment:
@@ -18,10 +17,10 @@ environment:
   CI: true
 tasks:
   - check-python:
-      python --version | grep 'Python 3.11'
+      python3 --version | grep 'Python 3.11'
   - tests: |
       cd django-renderpdf
-      tox  -e py
+      tox -e py311
   - lint: |
       cd django-renderpdf
-      tox  -e lint
+      tox -e lint

--- a/.builds/python3.14.yml
+++ b/.builds/python3.14.yml
@@ -17,7 +17,7 @@ environment:
   CI: true
 tasks:
   - check-python:
-      python --version | grep 'Python 3.13'
+      python --version | grep 'Python 3.14'
   - tests: |
       cd django-renderpdf
       tox  -e py

--- a/django_renderpdf/helpers.py
+++ b/django_renderpdf/helpers.py
@@ -1,6 +1,7 @@
 import mimetypes
 from collections.abc import Callable
 from collections.abc import Sequence
+from contextlib import suppress
 from typing import IO
 
 from django.conf import settings
@@ -18,6 +19,31 @@ from weasyprint import default_url_fetcher
 # Renaming this would required chaning public API and a major release:
 class InvalidRelativeUrl(ValueError):  # noqa: N818
     """Raised when a relative URL cannot be handled by Django."""
+
+
+def _read_staticfile(url: str, base_url: str) -> dict:
+    filename = url.replace(base_url, "", 1)
+    data = None
+
+    path = finders.find(filename)
+    if path:
+        # Read static files from source (e.g.: the file that's bundled with the Django
+        # app that provides it. This also picks up uncollected staticfiles which is
+        # useful when developing / in DEBUG mode.
+        with open(path, "rb") as f:
+            data = f.read()
+    else:
+        # File was not found by a finder. This commonly happens when running in
+        # DEBUG=True with a storage that uses Manifests or alike, since the filename
+        # won't match with the source file. In these cases, use the _storage_ to find
+        # the file instead:
+        with staticfiles_storage.open(filename) as f:
+            data = f.read()
+
+    return {
+        "mime_type": mimetypes.guess_type(url)[0],
+        "string": data,
+    }
 
 
 def django_url_fetcher(url: str) -> dict:
@@ -38,39 +64,17 @@ def django_url_fetcher(url: str) -> dict:
     resources data as a string and ``mime_type``, which is the identified
     mime type for the resource.
     """
+
     # If the URL looks like a staticfile, try to load it as such.
-    # Reading it from the storage avoids a network call in many cases (unless the
-    # storage is remote, in which case this improves nothing:
+    # Reading it from the storage avoids the HTTP round-trip in many cases.
     try:
-        base_url = getattr(staticfiles_storage, "base_url", None)
-        if base_url is not None and url.startswith(base_url):
-            filename = url.replace(base_url, "", 1)
-            data = None
-
-            path = finders.find(filename)
-            if path:
-                # Read static files from source (e.g.: the file that's bundled with the
-                # Django app that provides it.
-                # This also picks up uncollected staticfiles (useful when developing /
-                # in DEBUG mode).
-                with open(path, "rb") as f:
-                    data = f.read()
-            else:
-                # File was not found by a finder. This commonly happens when running in
-                # DEBUG=True with a storage that uses Manifests or alike, since the
-                # filename won't match with the source file.
-                # In these cases, use the _storage_ to find the file instead:
-                with staticfiles_storage.open(filename) as f:
-                    data = f.read()
-
-            return {
-                "mime_type": mimetypes.guess_type(url)[0],
-                "string": data,
-            }
-    except (ValueError, FileNotFoundError):
-        # Looks like this wasn't a staticfile (or maybe it was a missing one?)
-        # Let it resolve as a normal URL.
-        pass
+        static_base_url = staticfiles_storage.base_url  # type: ignore[attr-defined]
+    except AttributeError:
+        pass  # Storage has no attribute base_url; fall back.
+    else:
+        if url.startswith(static_base_url):
+            with suppress(ValueError, FileNotFoundError):
+                return _read_staticfile(url, static_base_url)
 
     try:
         # If the URL is a relative URL, use Django's resolver to figure out how Django

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [build-system]
+build-backend = "setuptools.build_meta"
 requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
 
 [project]

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+isolated_build = True
 envlist =
   py{310,311,312}-django42
   py{310,311,312,313}-django51


### PR DESCRIPTION
Fixes: https://github.com/WhyNotHugo/django-renderpdf/issues/63